### PR TITLE
nginx: disable uploadprogress module, add connection_upgrade map, dro…

### DIFF
--- a/pyinfra_nginx/connection_upgrade.conf
+++ b/pyinfra_nginx/connection_upgrade.conf
@@ -1,0 +1,4 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/pyinfra_nginx/nginx.py
+++ b/pyinfra_nginx/nginx.py
@@ -18,6 +18,35 @@ def deploy_nginx(**pyinfra_args):
         packages=["nginx-extras"],
     )
 
+    # Define $connection_upgrade so proxied vhosts can set the Connection
+    # header per-request (upgrade for websockets, close otherwise) instead of
+    # hardcoding "upgrade", which breaks ordinary keepalive requests.
+    upgrade_map = files.put(
+        name="Add connection_upgrade map",
+        src=importlib.resources.files(__package__) / "connection_upgrade.conf",
+        dest="/etc/nginx/conf.d/connection_upgrade.conf",
+        user="root",
+        group="root",
+        mode="644",
+    )
+
+    # The abandoned ngx_http_uploadprogress module (shipped by nginx-extras)
+    # segfaults nginx workers under concurrent proxied request bursts; unload
+    # the module
+    uploadprogress = files.link(
+        name="Disable uploadprogress nginx module",
+        path="/etc/nginx/modules-enabled/50-mod-http-uploadprogress.conf",
+        present=False,
+    )
+
+    systemd.service(
+        name="reload NGINX after base config changes",
+        service="nginx.service",
+        running=True,
+        enabled=True,
+        reloaded=(upgrade_map.changed or uploadprogress.changed),
+    )
+
 
 @contextlib.contextmanager
 def nginx_deployer(reload_nginx: bool = False, **pyinfra_args):
@@ -118,7 +147,7 @@ class NGINX:
             elif proxy_port:
                 if websocket_support:
                     websocket_config = '''proxy_set_header\tUpgrade $http_upgrade;
-        proxy_set_header\tConnection "upgrade";
+        proxy_set_header\tConnection $connection_upgrade;
         proxy_read_timeout\t86400;'''
                 else:
                     websocket_config = ''

--- a/pyinfra_nginx/proxy_pass.nginx_config.j2
+++ b/pyinfra_nginx/proxy_pass.nginx_config.j2
@@ -12,8 +12,8 @@ server {
         proxy_pass http://127.0.0.1:{{ proxy_port }}/;
 	}
 
-    listen [::]:443 ssl http2;
-    listen 443 ssl http2;
+    listen [::]:443 ssl;
+    listen 443 ssl;
     ssl_certificate /var/lib/acme/live/{{ domain }}/fullchain; # managed by acmetool
     ssl_certificate_key /var/lib/acme/live/{{ domain }}/privkey; # managed by acmetool
 }

--- a/pyinfra_nginx/webroot.nginx_config.j2
+++ b/pyinfra_nginx/webroot.nginx_config.j2
@@ -6,8 +6,8 @@ server {
         try_files $uri $uri/ $uri.html =404;
 	}
 
-    listen [::]:443 ssl http2;
-    listen 443 ssl http2;
+    listen [::]:443 ssl;
+    listen 443 ssl;
     ssl_certificate /var/lib/acme/live/{{ domain }}/fullchain; # managed by acmetool
     ssl_certificate_key /var/lib/acme/live/{{ domain }}/privkey; # managed by acmetool
 }


### PR DESCRIPTION
Fix three issues that surfaced during the b1 Ubuntu 24.04 / Grafana 13 upgrade:

- ngx_http_uploadprogress shipped by nginx-extras is abandoned and its rewrite-phase segfaults workers under concurrent proxied requests; deploy_nginx() now removes the modules-enabled symlink so the module is not loaded.

- proxy vhosts hardcoded `Connection "upgrade"` which resets ordinary keepalive requests. deploy_nginx() now adds /etc/nginx/conf.d/connection_upgrade.conf with a `map $http_upgrade $connection_upgrade` and the websocket_config in add_nginx_domain() uses $connection_upgrade so the header is only "upgrade" for actual websocket requests.

- `listen 443 ssl http2` is socket-wide in nginx 1.24, not per-vhost, and incompatible with Grafana Live's websockets, remove http2 from proxy_pass and webroot templates. Revisit with the per-server `http2 on;` directive once nginx 1.25+ (Ubuntu 26.04) is out